### PR TITLE
Invalid metrics fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,4 +25,5 @@ create-stack:build/cloudwatch-metrics-publisher.json
 	--template-body "file://${PWD}/build/cloudwatch-metrics-publisher.json" \
 	--capabilities CAPABILITY_IAM \
 	--parameters ParameterKey=BuildkiteApiAccessToken,ParameterValue=${BUILDKITE_API_ACCESS_TOKEN} \
-		ParameterKey=BuildkiteOrgSlug,ParameterValue=${BUILDKITE_ORG_SLUG}
+		ParameterKey=BuildkiteOrgSlug,ParameterValue=${BUILDKITE_ORG_SLUG} \
+                ParameterKey=Queue,ParameterValue=${QUEUE}

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Publish [Buildkite](https://buildkite.com/) job queue statistics to [AWS Cloudwa
 
 ## Installing
 
-The easiest way to install is to press the above button and then enter your org slug and your [Buildkite API Access Token](https://buildkite.com/user/api-access-tokens) with `read_projects` permissions created.
+The easiest way to install is to press the above button and then enter your org slug, your [Buildkite API Access Token](https://buildkite.com/user/api-access-tokens) with `read_builds` permissions created and the queue for which to collect metrics.
 
 Alternately, run via the command-line:
 
@@ -18,7 +18,8 @@ aws cloudformation create-stack \
 	--template-body "https://s3.amazonaws.com/buildkite-cloudwatch-metrics-publisher/cloudwatch-metrics-publisher.json" \
 	--capabilities CAPABILITY_IAM \
 	--parameters ParameterKey=BuildkiteApiAccessToken,ParameterValue=BUILDKITE_API_TOKEN_GOES_HERE \
-	ParameterKey=BuildkiteOrgSlug,ParameterValue=BUILDKITE_ORG_SLUG_GOES_HERE
+	ParameterKey=BuildkiteOrgSlug,ParameterValue=BUILDKITE_ORG_SLUG_GOES_HERE \
+        ParameterKey=Queue,ParameterValue=QUEUE_GOES_HERE
 ```
 
 After the stack is run you will have the following metrics populated in CloudWatch (updated every 5 minutes):
@@ -32,10 +33,6 @@ Buildkite > (Queue) > RunningBuildsCount
 Buildkite > (Queue) > RunningJobsCount
 Buildkite > (Queue) > ScheduledBuildsCount
 Buildkite > (Queue) > ScheduledJobsCount
-Buildkite > (Pipeline) > RunningBuildsCount
-Buildkite > (Pipeline) > RunningJobsCount
-Buildkite > (Pipeline) > ScheduledBuildsCount
-Buildkite > (Pipeline) > ScheduledJobsCount
 ```
 
 ## Developing

--- a/functions/collect-metrics/buildkite/buildkite.go
+++ b/functions/collect-metrics/buildkite/buildkite.go
@@ -49,7 +49,7 @@ type Job struct {
 
 // parses job metadata and extracts queue=xyz
 func (j Job) Queue() string {
-	for _, m := range j.Agent.Metadata {
+	for _, m := range j.AgentQueryRules {
 		if match := queuePattern.FindStringSubmatch(m); match != nil {
 			return match[1]
 		}

--- a/functions/collect-metrics/main.go
+++ b/functions/collect-metrics/main.go
@@ -155,15 +155,15 @@ func (r Result) extractMetricData() []*cloudwatch.MetricDatum {
 	data := []*cloudwatch.MetricDatum{}
 	data = append(data, r.Counts.asMetrics(nil)...)
 
-	for name, _ := range r.Queues {
-		data = append(data, r.Counts.asMetrics([]*cloudwatch.Dimension{
+	for name, c := range r.Queues {
+		data = append(data, c.asMetrics([]*cloudwatch.Dimension{
 			{Name: aws.String("Queue"), Value: aws.String(name)},
 		})...)
 	}
 
 	// write pipeline metrics, include project dimension for backwards compat
-	for name, _ := range r.Pipelines {
-		data = append(data, r.Counts.asMetrics([]*cloudwatch.Dimension{
+	for name, c := range r.Pipelines {
+		data = append(data, c.asMetrics([]*cloudwatch.Dimension{
 			{Name: aws.String("Project"), Value: aws.String(name)},
 			{Name: aws.String("Pipeline"), Value: aws.String(name)},
 		})...)

--- a/functions/collect-metrics/main.go
+++ b/functions/collect-metrics/main.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-	"time"
 
 	"github.com/apex/go-apex"
 	"github.com/aws/aws-sdk-go/aws"

--- a/templates/cloudformation.yml
+++ b/templates/cloudformation.yml
@@ -9,6 +9,10 @@ Parameters:
     Description: Your Buildkite organization slug
     Type: String
 
+  Queue:
+    Description: The Build Queue to collect stats for
+    Type: String
+
 Resources:
   LambdaExecutionRole:
     Type: AWS::IAM::Role
@@ -60,7 +64,8 @@ Resources:
               FunctionName: '$(CollectMetrics)',
               Payload: JSON.stringify({
                 BuildkiteApiAccessToken: '$(BuildkiteApiAccessToken)',
-                BuildkiteOrgSlug: '$(BuildkiteOrgSlug)'
+                BuildkiteOrgSlug: '$(BuildkiteOrgSlug)',
+                Queue: '$(Queue)'
               }, null, 2)
             }, function(error, data) {
               if (error) {


### PR DESCRIPTION
Various bug fixes.
- Now requires Queue to be passed in as a parameter. This queue; the 'default' queue; and the global metrics are now only updated. Removed pipeline specific metrics as their values would be left as their previous values once they were zeroed.
- Uses agent query rules to work out the queue instead of the agent. As the agent maybe null it was incorrectly returning the queue as 'default'
- extractMetricData method was incorrectly appending the global metrics instead of the metric for the queue.
