### PR TITLE
Load 72 hours worth of historical data to ensure counters are zero'd

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ make upload
 make create-stack
 ```
 
+Or you can test functions directly:
+
+```
+go run functions/collect-metrics/*.go <<< '{ "event": { "BuildkiteApiAccessToken": "xyz", "BuildkiteOrgSlug": "myslug" } }'
+```
+
 ## License
 
 See [LICENSE.md](LICENSE.md) (MIT)

--- a/functions/collect-metrics/buildkite/buildkite.go
+++ b/functions/collect-metrics/buildkite/buildkite.go
@@ -1,6 +1,19 @@
 package buildkite
 
-import "regexp"
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"regexp"
+	"time"
+
+	"github.com/tent/http-link-go"
+)
+
+const (
+	dateFormat = "2006-01-02T15:04:05Z"
+)
 
 var queuePattern *regexp.Regexp
 
@@ -21,35 +34,35 @@ type Provider struct {
 }
 
 type Creator struct {
-	AvatarURL string `json:"avatar_url"`
-	CreatedAt string `json:"created_at"`
-	Email     string `json:"email"`
-	ID        string `json:"id"`
-	Name      string `json:"name"`
+	AvatarURL string     `json:"avatar_url"`
+	CreatedAt *time.Time `json:"created_at"`
+	Email     string     `json:"email"`
+	ID        string     `json:"id"`
+	Name      string     `json:"name"`
 }
 
 type Job struct {
-	Agent           Agent    `json:"agent"`
-	AgentQueryRules []string `json:"agent_query_rules"`
-	ArtifactPaths   string   `json:"artifact_paths"`
-	Command         string   `json:"command"`
-	CreatedAt       string   `json:"created_at"`
-	ExitStatus      int      `json:"exit_status"`
-	FinishedAt      string   `json:"finished_at"`
-	ID              string   `json:"id"`
-	LogURL          string   `json:"log_url"`
-	Name            string   `json:"name"`
-	RawLogURL       string   `json:"raw_log_url"`
-	ScheduledAt     string   `json:"scheduled_at"`
-	StartedAt       string   `json:"started_at"`
-	State           string   `json:"state"`
-	Type            string   `json:"type"`
-	WebURL          string   `json:"web_url"`
+	Agent           Agent      `json:"agent"`
+	AgentQueryRules []string   `json:"agent_query_rules"`
+	ArtifactPaths   string     `json:"artifact_paths"`
+	Command         string     `json:"command"`
+	CreatedAt       *time.Time `json:"created_at"`
+	ExitStatus      int        `json:"exit_status"`
+	FinishedAt      *time.Time `json:"finished_at"`
+	ID              string     `json:"id"`
+	LogURL          string     `json:"log_url"`
+	Name            string     `json:"name"`
+	RawLogURL       string     `json:"raw_log_url"`
+	ScheduledAt     *time.Time `json:"scheduled_at"`
+	StartedAt       *time.Time `json:"started_at"`
+	State           string     `json:"state"`
+	Type            string     `json:"type"`
+	WebURL          string     `json:"web_url"`
 }
 
-// parses job metadata and extracts queue=xyz
+// parses the the target queue based on queue=xyz in the AgentQueryRules
 func (j Job) Queue() string {
-	for _, m := range j.Agent.Metadata {
+	for _, m := range j.AgentQueryRules {
 		if match := queuePattern.FindStringSubmatch(m); match != nil {
 			return match[1]
 		}
@@ -58,39 +71,149 @@ func (j Job) Queue() string {
 }
 
 type Pipeline struct {
-	BuildsURL            string   `json:"builds_url"`
-	CreatedAt            string   `json:"created_at"`
-	ID                   string   `json:"id"`
-	Name                 string   `json:"name"`
-	Provider             Provider `json:"provider"`
-	Repository           string   `json:"repository"`
-	RunningBuildsCount   int      `json:"running_builds_count"`
-	RunningJobsCount     int      `json:"running_jobs_count"`
-	ScheduledBuildsCount int      `json:"scheduled_builds_count"`
-	ScheduledJobsCount   int      `json:"scheduled_jobs_count"`
-	Slug                 string   `json:"slug"`
-	URL                  string   `json:"url"`
-	WaitingJobsCount     int      `json:"waiting_jobs_count"`
-	WebURL               string   `json:"web_url"`
+	BuildsURL            string     `json:"builds_url"`
+	CreatedAt            *time.Time `json:"created_at"`
+	ID                   string     `json:"id"`
+	Name                 string     `json:"name"`
+	Provider             Provider   `json:"provider"`
+	Repository           string     `json:"repository"`
+	RunningBuildsCount   int        `json:"running_builds_count"`
+	RunningJobsCount     int        `json:"running_jobs_count"`
+	ScheduledBuildsCount int        `json:"scheduled_builds_count"`
+	ScheduledJobsCount   int        `json:"scheduled_jobs_count"`
+	Slug                 string     `json:"slug"`
+	URL                  string     `json:"url"`
+	WaitingJobsCount     int        `json:"waiting_jobs_count"`
+	WebURL               string     `json:"web_url"`
 }
 
 type Build struct {
 	Branch      string                 `json:"branch"`
 	Commit      string                 `json:"commit"`
-	CreatedAt   string                 `json:"created_at"`
+	CreatedAt   *time.Time             `json:"created_at"`
 	Creator     Creator                `json:"creator"`
 	Env         map[string]interface{} `json:"env"`
-	FinishedAt  string                 `json:"finished_at"`
+	FinishedAt  *time.Time             `json:"finished_at"`
 	ID          string                 `json:"id"`
 	Jobs        []Job                  `json:"jobs"`
 	Message     string                 `json:"message"`
 	MetaData    map[string]interface{} `json:"meta_data"`
 	Number      int                    `json:"number"`
 	Pipeline    Pipeline               `json:"pipeline"`
-	ScheduledAt string                 `json:"scheduled_at"`
+	ScheduledAt *time.Time             `json:"scheduled_at"`
 	Source      string                 `json:"source"`
-	StartedAt   string                 `json:"started_at"`
+	StartedAt   *time.Time             `json:"started_at"`
 	State       string                 `json:"state"`
 	URL         string                 `json:"url"`
 	WebURL      string                 `json:"web_url"`
+}
+
+func nextLink(linkheader string) (*url.URL, error) {
+	links, err := link.Parse(linkheader)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, link := range links {
+		if link.Rel == "next" {
+			return url.Parse(link.URI)
+		}
+	}
+
+	return nil, nil
+}
+
+func paginate(req *http.Request, f func(resp *http.Response) error) error {
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("Failed to request %s", req.URL)
+	}
+
+	err = f(resp)
+	if err != nil {
+		return err
+	}
+
+	next, err := nextLink(resp.Header.Get("Link"))
+	if err != nil {
+		return err
+	}
+
+	if next != nil {
+		req.URL = next
+		return paginate(req, f)
+	}
+
+	return nil
+}
+
+type BuildsInput struct {
+	OrgSlug                string
+	ApiToken               string
+	CreatedFrom, CreatedTo time.Time
+}
+
+func (i *BuildsInput) URL() (*url.URL, error) {
+	u, err := url.Parse(fmt.Sprintf(
+		"https://api.buildkite.com/v2/organizations/%s/builds?per_page=100&page=1",
+		i.OrgSlug,
+	))
+	if err != nil {
+		return u, err
+	}
+
+	v := u.Query()
+
+	if !i.CreatedFrom.IsZero() {
+		v.Set("created_from", i.CreatedFrom.Format(dateFormat))
+	}
+
+	if !i.CreatedTo.IsZero() {
+		v.Set("created_to", i.CreatedTo.Format(dateFormat))
+	}
+
+	u.RawQuery = v.Encode()
+	return u, nil
+}
+
+type BuildsOutput struct {
+	Builds []Build
+	Pages  int
+}
+
+func Builds(input *BuildsInput) (out BuildsOutput, err error) {
+	u, err := input.URL()
+	if err != nil {
+		return out, err
+	}
+
+	req, err := http.NewRequest("GET", u.String(), nil)
+	if err != nil {
+		return out, err
+	}
+
+	// https://buildkite.com/docs/api#authentication
+	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", input.ApiToken))
+
+	out.Builds = []Build{}
+	err = paginate(req, func(resp *http.Response) error {
+		var page []Build
+		if err := json.NewDecoder(resp.Body).Decode(&page); err != nil {
+			return err
+		}
+		out.Builds = append(out.Builds, page...)
+		return nil
+	})
+
+	if err != nil {
+		return out, err
+	}
+
+	return out, nil
 }

--- a/functions/collect-metrics/main.go
+++ b/functions/collect-metrics/main.go
@@ -13,8 +13,6 @@ import (
 	"github.com/buildkite/buildkite-cloudwatch-metrics-publisher/functions/collect-metrics/buildkite"
 )
 
-var historicalData = time.Hour * -72
-
 // Generates:
 // Buildkite > RunningBuildsCount
 // Buildkite > RunningJobsCount
@@ -34,7 +32,6 @@ func main() {
 		svc := cloudwatch.New(session.New())
 
 		var conf Config
-
 		if err := json.Unmarshal(event, &conf); err != nil {
 			return nil, err
 		}
@@ -47,57 +44,72 @@ func main() {
 			return nil, errors.New("No BuildkiteOrgSlug provided")
 		}
 
-		cutoff := time.Now().UTC().Add(time.Minute * -5)
+		var res *Result = &Result{
+			Queues:    map[string]Counts{},
+			Pipelines: map[string]Counts{},
+		}
 
-		log.Printf("Querying buildkite for builds for org %s after %s",
-			conf.BuildkiteOrgSlug,
-			time.Now().UTC().Add(historicalData).String())
+		// Algorithm:
+		// Get Builds with finished_from = 24 hours ago
+		// Build results with zero values for pipelines/queues
+		// Get all running and scheduled builds, add to results
 
 		builds, err := buildkite.Builds(&buildkite.BuildsInput{
-			OrgSlug:     conf.BuildkiteOrgSlug,
-			ApiToken:    conf.BuildkiteApiAccessToken,
-			CreatedFrom: time.Now().UTC().Add(historicalData),
-			CreatedTo:   time.Now().UTC(),
+			OrgSlug:      conf.BuildkiteOrgSlug,
+			ApiToken:     conf.BuildkiteApiAccessToken,
+			FinishedFrom: time.Now().UTC().Add(time.Hour * -24),
 		})
 		if err != nil {
 			return nil, err
 		}
 
-		var res Result = Result{
-			Queues:    map[string]Counts{"default": Counts{}},
-			Pipelines: map[string]Counts{},
+		for _, queue := range builds.Queues() {
+			res.Queues[queue] = Counts{}
 		}
 
-		log.Printf("Aggregating results from %d builds", len(builds.Builds))
-
-		for _, build := range builds.Builds {
+		for _, build := range builds {
 			if _, ok := res.Pipelines[build.Pipeline.Name]; !ok {
 				res.Pipelines[build.Pipeline.Name] = Counts{}
 			}
+		}
 
-			var buildQueues = map[string]int{}
-			for _, job := range build.Jobs {
-				if _, ok := res.Queues[job.Queue()]; !ok {
-					res.Queues[job.Queue()] = Counts{}
-				}
+		states := []string{"scheduled", "running"}
 
-				if afterTime(cutoff, job.CreatedAt, job.FinishedAt, job.ScheduledAt, job.StartedAt) {
-					log.Printf("Adding job to stats (id=%q, pipeline=%q, queue=%s)", job.ID, build.Pipeline.Name, job.Queue())
+		for _, state := range states {
+			builds, err := buildkite.Builds(&buildkite.BuildsInput{
+				OrgSlug:  conf.BuildkiteOrgSlug,
+				ApiToken: conf.BuildkiteApiAccessToken,
+				State:    state,
+			})
+			if err != nil {
+				return nil, err
+			}
+
+			for _, build := range builds {
+				log.Printf("Adding build to stats (id=%q, pipeline=%q, branch=%q, state=%q)",
+					build.ID, build.Pipeline.Name, build.Branch, build.State)
+
+				res.Counts = res.Counts.addBuild(build)
+				res.Pipelines[build.Pipeline.Name] = res.Pipelines[build.Pipeline.Name].addBuild(build)
+
+				var buildQueues = map[string]int{}
+
+				for _, job := range build.Jobs {
+					log.Printf("Adding job to stats (id=%q, pipeline=%q, queue=%q, type=%q, state=%q)",
+						job.ID, build.Pipeline.Name, job.Queue(), job.Type, job.State)
+
 					res.Counts = res.Counts.addJob(job)
 					res.Pipelines[build.Pipeline.Name] = res.Pipelines[build.Pipeline.Name].addJob(job)
 					res.Queues[job.Queue()] = res.Queues[job.Queue()].addJob(job)
 					buildQueues[job.Queue()]++
 				}
-			}
 
-			if len(buildQueues) > 0 {
-				log.Printf("Adding build to stats (id=%q, pipeline=%q)", build.ID, build.Pipeline.Name)
-				res.Counts = res.Counts.addBuild(build)
-				res.Pipelines[build.Pipeline.Name] = res.Pipelines[build.Pipeline.Name].addBuild(build)
-			}
-
-			for queue := range buildQueues {
-				res.Queues[queue] = res.Queues[queue].addBuild(build)
+				if len(buildQueues) > 0 {
+					for queue := range buildQueues {
+						log.Printf("Adding stats for build to queue %s", queue)
+						res.Queues[queue] = res.Queues[queue].addBuild(build)
+					}
+				}
 			}
 		}
 
@@ -106,7 +118,7 @@ func main() {
 
 		for _, chunk := range chunkMetricData(10, metrics) {
 			log.Printf("Submitting chunk of %d metrics to Cloudwatch", len(chunk))
-			if err = putMetricData(svc, chunk); err != nil {
+			if err := putMetricData(svc, chunk); err != nil {
 				return nil, err
 			}
 		}
@@ -177,7 +189,7 @@ type Result struct {
 	Queues, Pipelines map[string]Counts
 }
 
-func (r Result) extractMetricData() []*cloudwatch.MetricDatum {
+func (r *Result) extractMetricData() []*cloudwatch.MetricDatum {
 	data := []*cloudwatch.MetricDatum{}
 	data = append(data, r.Counts.asMetrics(nil)...)
 


### PR DESCRIPTION
@daveoxley pointed out a number of bugs with the current approach, namely that builds and jobs that ran for longer than the 5 minute window would have their data lost, as the current approach only considers builds/jobs created within that window, not ones that finish or update during that window.

This PR fixes that by pulling in 72 hours worth of historical data, but only providing non-zero stats for those that were created, started, scheduled or finished within the last 5 minutes. 

This also fixes a bug where `extractMetricData` was looking at the global stats for pipelines and queues. 
