### PR TITLE
Add an optional instance updating stats every 30s

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,9 +20,11 @@ upload: build/cloudwatch-metrics-publisher.json build/lambda-timer.zip build/col
 create-stack:build/cloudwatch-metrics-publisher.json
 	aws cloudformation create-stack \
 	--output text \
-	--stack-name bk-metrics-$(shell date +%Y-%m-%d-%H-%M) \
+	--stack-name buildkite-metrics-$(shell date +%Y-%m-%d-%H-%M) \
 	--disable-rollback \
 	--template-body "file://${PWD}/build/cloudwatch-metrics-publisher.json" \
 	--capabilities CAPABILITY_IAM \
 	--parameters ParameterKey=BuildkiteApiAccessToken,ParameterValue=${BUILDKITE_API_ACCESS_TOKEN} \
-		ParameterKey=BuildkiteOrgSlug,ParameterValue=${BUILDKITE_ORG_SLUG}
+		ParameterKey=BuildkiteOrgSlug,ParameterValue=${BUILDKITE_ORG_SLUG} \
+		ParameterKey=KeyName,ParameterValue=${KEY_NAME} \
+		ParameterKey=UsePollerInstance,ParameterValue=true

--- a/templates/cloudformation.yml
+++ b/templates/cloudformation.yml
@@ -9,6 +9,15 @@ Parameters:
     Description: Your Buildkite organization slug
     Type: String
 
+  KeyName:
+    Description: The ssh keypair used to access the timer instance
+    Type: AWS::EC2::KeyPair::KeyName
+    Default: default
+
+Conditions:
+    UseSpotInstances:
+      !Not [ !Equals [ 0, 0 ] ]
+
 Resources:
   LambdaExecutionRole:
     Type: AWS::IAM::Role
@@ -74,7 +83,6 @@ Resources:
       Runtime: nodejs
       Timeout: 25
 
-
   LambdaTimerService:
     Type: AWS::Lambda::Function
     Properties:
@@ -93,3 +101,43 @@ Resources:
       Name: $(AWS::StackName)-LambdaTimer
       ScheduleExpression: rate(5 minutes)
       LambdaArn: $(InvokeCollectMetrics[Arn])
+
+  TimerInstanceIAMRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: [ ec2.amazonaws.com ]
+            Action: sts:AssumeRole
+      Path: "/"
+      Policies:
+        - PolicyName: root
+          PolicyDocument:
+            Statement:
+              - Effect: Allow
+                Action:
+                  - lambda:*
+                Resource: $(InvokeCollectMetrics[Arn])
+
+  TimerInstanceProfile:
+    Type: AWS::IAM::InstanceProfile
+    Properties:
+      Path: /
+      Roles: [ $(TimerInstanceIAMRole) ]
+
+  TimerInstance:
+    Type: AWS::EC2::Instance
+    Properties:
+      KeyName: $(KeyName)
+      InstanceType: t2.nano
+      ImageId: ami-8fcee4e5
+      IamInstanceProfile: $(TimerInstanceProfile)
+      UserData: !Base64 |
+        #!/bin/bash -xv
+        export AWS_DEFAULT_REGION=$(AWS::Region)
+        while true ; do
+          aws lambda invoke --function-name "$(InvokeCollectMetrics[Arn])" -
+          sleep 30
+        done

--- a/templates/cloudformation.yml
+++ b/templates/cloudformation.yml
@@ -9,14 +9,20 @@ Parameters:
     Description: Your Buildkite organization slug
     Type: String
 
+  UsePollerInstance:
+    Description: Whether to use a polling instance for 30 second resolution
+    Type: String
+    Default: "false"
+    AllowedValues: ["true","false"]
+
   KeyName:
     Description: The ssh keypair used to access the timer instance
     Type: AWS::EC2::KeyPair::KeyName
     Default: default
 
 Conditions:
-    UseSpotInstances:
-      !Not [ !Equals [ 0, 0 ] ]
+    UsePollerInstance:
+      !Equals [ "true", $(UsePollerInstance) ]
 
 Resources:
   LambdaExecutionRole:
@@ -103,6 +109,7 @@ Resources:
       LambdaArn: $(InvokeCollectMetrics[Arn])
 
   TimerInstanceIAMRole:
+    Condition: UsePollerInstance
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
@@ -122,12 +129,14 @@ Resources:
                 Resource: $(InvokeCollectMetrics[Arn])
 
   TimerInstanceProfile:
+    Condition: UsePollerInstance
     Type: AWS::IAM::InstanceProfile
     Properties:
       Path: /
       Roles: [ $(TimerInstanceIAMRole) ]
 
   TimerInstance:
+    Condition: UsePollerInstance
     Type: AWS::EC2::Instance
     Properties:
       KeyName: $(KeyName)


### PR DESCRIPTION
Currently Cloudwatch Events is limited to a minimum recurrence schedule of `5 minutes`. This adds a t2.nano instance ($4.75USD/month) that increases this to every 30 seconds.
