### PR TITLE
Check ec2 instance starts up in Cloudformation

### DIFF
--- a/templates/cloudformation.yml
+++ b/templates/cloudformation.yml
@@ -52,6 +52,14 @@ Resources:
       AvailabilityZones: !GetAZs
       MinSize: 1
       MaxSize: 1
+      Tags:
+        - Key: Role
+          Value: buildkite-metrics
+          PropagateAtLaunch: true
+
+    CreationPolicy:
+      ResourceSignal:
+        Timeout: PT5M
 
   SecurityGroup:
     Type: AWS::EC2::SecurityGroup
@@ -75,9 +83,9 @@ Resources:
       UserData: !Base64 |
         #!/bin/bash -xve
         export INSTANCE=\$(curl http://169.254.169.254/latest/meta-data/instance-id)
-        aws s3 cp $(BinUrl) /usr/bin/buildkite-cloudwatch-metrics
-        chmod +x /usr/bin/buildkite-cloudwatch-metrics
+        aws s3 cp $(BinUrl) /usr/bin/buildkite-cloudwatch-metrics \
+          && chmod +x /usr/bin/buildkite-cloudwatch-metrics
+        /opt/aws/bin/cfn-signal -e \$? \
+            --stack $(AWS::StackName) --resource 'AutoScalingGroup' --region $(AWS::Region)
         /usr/bin/buildkite-cloudwatch-metrics -org "$(BuildkiteOrgSlug)" -token "$(BuildkiteApiAccessToken)" -interval 30s
         aws autoscaling set-instance-health --instance-id \$INSTANCE --health-status Unhealthy
-
-

--- a/templates/cloudformation.yml
+++ b/templates/cloudformation.yml
@@ -15,9 +15,9 @@ Parameters:
     Default: default
 
   BinUrl:
-    Description: The s3 path to download the binary from
+    Description: The url to download the binary from
     Type: String
-    Default: s3://buildkite-cloudwatch-metrics-publisher/master/buildkite-cloudwatch-metrics
+    Default: http://s3.amazonaws.com://buildkite-cloudwatch-metrics-publisher/master/buildkite-cloudwatch-metrics
 
 Resources:
   IAMRole:
@@ -83,7 +83,7 @@ Resources:
       UserData: !Base64 |
         #!/bin/bash -xve
         export INSTANCE=\$(curl http://169.254.169.254/latest/meta-data/instance-id)
-        aws s3 cp $(BinUrl) /usr/bin/buildkite-cloudwatch-metrics \
+        curl -Lf $(BinUrl) -o /usr/bin/buildkite-cloudwatch-metrics \
           && chmod +x /usr/bin/buildkite-cloudwatch-metrics
         /opt/aws/bin/cfn-signal -e \$? \
             --stack $(AWS::StackName) --resource 'AutoScalingGroup' --region $(AWS::Region)


### PR DESCRIPTION
Previously the instance that runs the poller could fail to startup and the stack would still be shown as successfully created. This adds a creation rule that checks it was successful. 
