### PR TITLE
Require VPC Subnets to be specified for launching metrics stack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,8 @@ keyname = default
 branch = $(shell git rev-parse --abbrev-ref HEAD)
 stackparams = ParameterKey=BuildkiteApiAccessToken,ParameterValue=$(token) \
 		ParameterKey=BuildkiteOrgSlug,ParameterValue=$(org) \
-		ParameterKey=KeyName,ParameterValue=$(keyname)
+		ParameterKey=KeyName,ParameterValue=$(keyname) \
+		ParameterKey=Subnets,ParameterValue=$(subnets) \
 
 ifdef binurl
   stackparams += ParameterKey=BinUrl,ParameterValue=$(binurl)

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ aws cloudformation create-stack \
 	--template-body "https://s3.amazonaws.com/buildkite-cloudwatch-metrics-publisher/master/cloudwatch-metrics-publisher.json" \
 	--capabilities CAPABILITY_IAM \
 	--parameters ParameterKey=BuildkiteApiAccessToken,ParameterValue=BUILDKITE_API_TOKEN_GOES_HERE \
-	ParameterKey=BuildkiteOrgSlug,ParameterValue=BUILDKITE_ORG_SLUG_GOES_HERE
+	ParameterKey=BuildkiteOrgSlug,ParameterValue=BUILDKITE_ORG_SLUG_GOES_HERE \
+	ParameterKey=Subnets,ParameterValue=VPC_SUBNETS_GO_HERE
 ```
 
 After the stack is run you will have the following metrics populated in CloudWatch (updated every 5 minutes):

--- a/templates/cloudformation.yml
+++ b/templates/cloudformation.yml
@@ -29,7 +29,9 @@ Parameters:
     Type: String
     Default: "30s"
 
-
+  Subnets:
+    Type: List<AWS::EC2::Subnet::Id>
+    Description: The VPC Subnets that the instance will run in
 
 Resources:
   IAMRole:
@@ -62,7 +64,7 @@ Resources:
     Type: AWS::AutoScaling::AutoScalingGroup
     Properties:
       LaunchConfigurationName: $(LaunchConfiguration)
-      AvailabilityZones: !GetAZs
+      VPCZoneIdentifier: $(Subnets)
       MinSize: 1
       MaxSize: 1
       Tags:


### PR DESCRIPTION
This adds a required Subnets parameter for the stack, which means that it will only work with VPCs. Without this parameter the behaviour for VPC accounts without a default subnet was strange and resulted in errors like in https://github.com/buildkite/buildkite-aws-stack/issues/42
