### PR TITLE
Always respawn

### DIFF
--- a/templates/cloudformation.yml
+++ b/templates/cloudformation.yml
@@ -148,7 +148,7 @@ Resources:
               group: root
               content: |
                 start on startup
-                respawn
+                respawn limit unlimited
                 env AWS_REGION=$(AWS::Region)
                 script
                     mkfifo /tmp/buildkite-cloudwatch-metrics-log-fifo

--- a/templates/cloudformation.yml
+++ b/templates/cloudformation.yml
@@ -148,6 +148,7 @@ Resources:
               group: root
               content: |
                 start on startup
+                respawn
                 respawn limit unlimited
                 env AWS_REGION=$(AWS::Region)
                 script


### PR DESCRIPTION
This adds a [respawn limit](http://upstart.ubuntu.com/cookbook/#respawn-limit) statement to ensure the metrics daemon restarts even in the case of Buildkite API downtime. Otherwise the default is to ensure that it doesn't restart more than 5 times in 10 seconds and then give up.
