### PR TITLE
Update image to 2016.09.0 and add new regions

### DIFF
--- a/templates/cloudformation.yml
+++ b/templates/cloudformation.yml
@@ -1,18 +1,21 @@
 
 Mappings:
 
-  # Amazon Linux AMI 2016.03.3 was released on 2016-06-28.
+  # Amazon Linux AMI 2016.09.0 was released on 2016-09-27.
   # HVM EBS-Backed 64-bit instances from https://aws.amazon.com/amazon-linux-ami/
   AWSRegion2AMI:
-    us-east-1:      { AMI: ami-6869aa05 }  # US East (N. Virginia)
-    us-west-2:      { AMI: ami-7172b611 }  # US West (Oregon)
-    us-west-1:      { AMI: ami-31490d51 }  # US West (N. California)
-    eu-west-1:      { AMI: ami-f9dd458a }  # EU (Ireland)
-    eu-central-2:   { AMI: ami-ea26ce85 }  # EU (Frankfurt)
-    ap-southeast-1: { AMI: ami-a59b49c6 }  # Asia Pacific (Singapore)
-    ap-northeast-1: { AMI: ami-374db956 }  # Asia Pacific (Tokyo)
-    ap-southeast-2: { AMI: ami-dc361ebf }  # Asia Pacific (Sydney)
-    sa-east-1:      { AMI: ami-6dd04501 }  # South America (São Paulo)
+    us-east-1:      { AMI: ami-b73b63a0 }  # US East (N. Virginia)
+    us-east-2:      { AMI: ami-58277d3d }  # US East (Ohio)
+    us-west-2:      { AMI: ami-5ec1673e }  # US West (Oregon)
+    us-west-1:      { AMI: ami-23e8a343 }  # US West (N. California)
+    eu-west-1:      { AMI: ami-9398d3e0 }  # EU (Ireland)
+    eu-central-2:   { AMI: ami-f9619996 }  # EU (Frankfurt)
+    ap-southeast-1: { AMI: ami-b953f2da }  # Asia Pacific (Singapore)
+    ap-northeast-2: { AMI: ami-983ce8f6 }  # Asia Pacific (Seoul)
+    ap-northeast-1: { AMI: ami-0c11b26d }  # Asia Pacific (Tokyo)
+    ap-southeast-2: { AMI: ami-db704cb8 }  # Asia Pacific (Sydney)
+    ap-south-1:     { AMI: ami-34b4c05b }  # Asia Pacific (Mumbai)
+    sa-east-1:      { AMI: ami-97831ffb }  # South America (São Paulo)
 
 Parameters:
   BuildkiteApiAccessToken:


### PR DESCRIPTION
Add support for `us-east-2`, `eu-central-1` and `ap-south-1`, also bump to latest Amazon Linux version.